### PR TITLE
Discard the transparent color

### DIFF
--- a/src/Shaders.elm
+++ b/src/Shaders.elm
@@ -177,6 +177,11 @@ void main () {
     vec2 spritePosition = (spriteOffset + delta) / atlasSize;
 
     gl_FragColor = texture2D(atlas, spritePosition);
+
+    // Discard the transparent color
+    if (gl_FragColor.a == 0.0) {
+      discard;
+    }
 }
 |]
 


### PR DESCRIPTION
When the depth test passes for the tree, all the pixels are drawn on the screen and into the depth buffer (even if they are transparent). So when you draw a character, it does not pass the depth test.

Since you don't have semi transparent pixels, you can discard the transparent colors from the output. I only did it for the `tiledRectFragmentShader`, you might need this for the rest.

![screen](https://cloud.githubusercontent.com/assets/43472/26083592/0d53fd2a-39d7-11e7-9ea1-f4faea24299b.gif)


Closes https://github.com/passiomatic/mage-city/issues/1

